### PR TITLE
Added check for file existence

### DIFF
--- a/src/ScreenshotManager.cs
+++ b/src/ScreenshotManager.cs
@@ -56,7 +56,7 @@ namespace BetterLoadSaveGame
 
         private bool IsFullScreenshot(string filename)
         {
-            return filename.EndsWith(".png") && !filename.EndsWith("-thumb.png") && File.Exists(Path.ChangeExtension(filename, ".sfs"));
+            return filename.EndsWith(".png") && !filename.EndsWith("-thumb.png") && File.Exists(filename) && File.Exists(Path.ChangeExtension(filename, ".sfs"));
         }
 
         private void SaveScreenshot(string filename)


### PR DESCRIPTION
Added check for file existence in IsFullScreenshot(), to eliminate the following error which happened during a revert:

`
[BetterLoadSaveGame] System.IO.IsolatedStorage.IsolatedStorageException: Could not find file "R:\KSP_1.6.1-Shuttle_Challenge\saves\Challenge-modTesting\persistent.png".
  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share, Int32 bufferSize, Boolean anonymous, FileOptions options) [0x00000] in <filename unknown>:0 
  at System.IO.FileStream..ctor (System.String path, FileMode mode, FileAccess access, FileShare share) [0x00000] in <filename unknown>:0 
  at System.IO.File.OpenRead (System.String path) [0x00000] in <filename unknown>:0 
  at System.IO.File.ReadAllBytes (System.String path) [0x00000] in <filename unknown>:0 
  at BetterLoadSaveGame.ScreenshotManager.https://github.com/linuxgurugamer/BetterLoadSaveGame.git (System.String filename) [0x00000] in <filename unknown>:0 
  at BetterLoadSaveGame.ScreenshotManager+<>c__DisplayClass8.<OnSave>b__5 () [0x00000] in <filename unknown>:0 
  at BetterLoadSaveGame.ActionGenerator.Update () [0x00000] in <filename unknown>:0 
  at BetterLoadSaveGame.Main.Update () [0x00000] in <filename unknown>:0 `